### PR TITLE
Smaller WebView fixes

### DIFF
--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -16,9 +16,9 @@ class MainScreen extends StatefulWidget {
 }
 
 class _MainScreenState extends State<MainScreen> {
+  late final WebViewManager webViewManagerController;
   var currentIndex = 0.obs;
   var title = 'Home'.obs;
-  final webViewManagerController = Get.find<WebViewManager>();
 
   final List<Widget> _pages = [
     const HomeScreen(),
@@ -26,6 +26,17 @@ class _MainScreenState extends State<MainScreen> {
     RecentListScreen(),
     BookMarksScreen(),
   ];
+
+  @override
+  void initState() {
+    super.initState();
+
+    webViewManagerController = Get.find<WebViewManager>();
+
+    // Make sure we only call this once during main screen initialization to
+    // also properly initialize the webView status
+    webViewManagerController.getVideoPlayerType();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/media_fetch_screen.dart
+++ b/lib/screens/media_fetch_screen.dart
@@ -10,6 +10,7 @@ import '../services/anime_service.dart';
 import '../theme/tako_theme.dart';
 import '../utils/constants.dart';
 import '../utils/routes.dart';
+import '../widgets/tako_play_web_view.dart';
 
 class MediaFetchScreen extends StatefulWidget {
   const MediaFetchScreen({Key? key}) : super(key: key);
@@ -20,7 +21,6 @@ class MediaFetchScreen extends StatefulWidget {
 
 class _MediaFetchScreenState extends State<MediaFetchScreen> {
   final GlobalKey webViewKey = GlobalKey();
-  WebViewController? _webViewController;
   final webViewManagerController = Get.find<WebViewManager>();
   final _random = Random();
   var hasError = false.obs;
@@ -67,26 +67,21 @@ class _MediaFetchScreenState extends State<MediaFetchScreen> {
                       if (snapshot.connectionState == ConnectionState.done) {
                         return SizedBox.fromSize(
                           size: Size(screenWidth / 1.5, screenHeight / 1.5),
-                          child: WebView(
+                          child: TakoPlayWebView(
                             initialUrl: 'https:${snapshot.data}',
-                            javascriptMode: JavascriptMode.unrestricted,
-                            allowsInlineMediaPlayback: true,
-                            onWebViewCreated: (controller) async {
-                              _webViewController = controller;
-                            },
-                            onPageFinished: (_) async {
+                            onLoadingFinished: (_webViewController) async {
                               mediaUrl = snapshot.data!;
                               // Ads Block
                               for (var i = 0; i < 8; i++) {
-                                await _webViewController!
+                                await _webViewController
                                     .runJavascriptReturningResult(
                                         "document.getElementsByTagName('iframe')[$i].style.display='none';");
-                                await _webViewController!
+                                await _webViewController
                                     .runJavascriptReturningResult(
                                         "document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].click();");
                               }
                               // Fetching VidStreaming Url
-                              String rawUrl = await _webViewController!
+                              String rawUrl = await _webViewController
                                   .runJavascriptReturningResult(
                                       "document.getElementsByClassName('jw-video jw-reset')[0].attributes.src.value;");
                               if (rawUrl == 'null') {
@@ -94,16 +89,16 @@ class _MediaFetchScreenState extends State<MediaFetchScreen> {
                               } else {
                                 String url = rawUrl.split('"').toList()[1];
 
-                                await _webViewController!
+                                await _webViewController
                                     .runJavascriptReturningResult(
                                         "if(document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].ariaLabel == 'Play'){document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].click();}");
-                                String resolutionCount = await _webViewController!
+                                String resolutionCount = await _webViewController
                                     .runJavascriptReturningResult(
                                         "document.getElementsByClassName('jw-reset jw-settings-submenu-items')[1].getElementsByClassName('jw-reset-text jw-settings-content-item')['length'];");
                                 for (var j = 0;
                                     j < double.parse(resolutionCount) - 1;
                                     j++) {
-                                  String rawResolution = await _webViewController!
+                                  String rawResolution = await _webViewController
                                       .runJavascriptReturningResult(
                                           "document.getElementsByClassName('jw-reset jw-settings-submenu-items')[1].getElementsByClassName('jw-reset-text jw-settings-content-item')[$j].textContent;");
                                   String resolution = rawResolution
@@ -126,10 +121,6 @@ class _MediaFetchScreenState extends State<MediaFetchScreen> {
                                     });
                               }
                             },
-                            navigationDelegate: (NavigationRequest request) {
-                              return NavigationDecision.prevent;
-                            },
-                            backgroundColor: const Color(0x00000000),
                           ),
                         );
                       } else {

--- a/lib/screens/webview_screen.dart
+++ b/lib/screens/webview_screen.dart
@@ -20,10 +20,17 @@ class _WebViewScreenState extends State<WebViewScreen> {
   var isLandScape = true.obs;
   final GlobalKey webViewKey = GlobalKey();
   WebViewController? _webViewController;
+
+  /// The initial url to start with
+  late final String _initialUrl;
+
   @override
   void initState() {
     super.initState();
+    _initialUrl = Get.arguments['mediaUrl'].toString();
+
     if (Platform.isAndroid) WebView.platform = AndroidWebView();
+    if (Platform.isIOS) WebView.platform = CupertinoWebView();
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
     ]);
@@ -93,29 +100,43 @@ class _WebViewScreenState extends State<WebViewScreen> {
                     },
                     onPageFinished: (_) async {
                       await Future.delayed(const Duration(seconds: 1));
-                      //
-                      for (var i = 0; i < 8; i++) {
+
+                      try {
+                        //
+                        for (var i = 0; i < 8; i++) {
+                          await _webViewController!.runJavascriptReturningResult(
+                              "document.getElementsByTagName('iframe')[$i].style.display='none';");
+                          await _webViewController!.runJavascriptReturningResult(
+                              "document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].click();");
+                        }
+                        //
+                        for (var i = 0; i < 8; i++) {
+                          await _webViewController!.runJavascriptReturningResult(
+                              "document.getElementsByTagName('iframe')[$i].style.display='none';");
+                        }
                         await _webViewController!.runJavascriptReturningResult(
-                            "document.getElementsByTagName('iframe')[$i].style.display='none';");
+                            "document.getElementsByClassName('jw-icon jw-icon-inline jw-button-color jw-reset jw-icon-fullscreen')[1].click();");
                         await _webViewController!.runJavascriptReturningResult(
-                            "document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].click();");
-                      }
-                      //
-                      for (var i = 0; i < 8; i++) {
-                        await _webViewController!.runJavascriptReturningResult(
-                            "document.getElementsByTagName('iframe')[$i].style.display='none';");
-                      }
-                      await _webViewController!.runJavascriptReturningResult(
-                          "document.getElementsByClassName('jw-icon jw-icon-inline jw-button-color jw-reset jw-icon-fullscreen')[1].click();");
-                      await _webViewController!.runJavascriptReturningResult(
-                          "if(document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].ariaLabel == 'Play'){document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].click();}");
-                      //
-                      for (var i = 0; i < 8; i++) {
-                        await _webViewController!.runJavascriptReturningResult(
-                            "document.getElementsByTagName('iframe')[$i].style.display='none';");
+                            "if(document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].ariaLabel == 'Play'){document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].click();}");
+                        //
+                        for (var i = 0; i < 8; i++) {
+                          await _webViewController!.runJavascriptReturningResult(
+                              "document.getElementsByTagName('iframe')[$i].style.display='none';");
+                        }
+                      } catch (e) {
+                        print(
+                            'An error occurred while parsing data from webview:');
+                        print(e.toString());
+                        rethrow;
                       }
                     },
                     navigationDelegate: (NavigationRequest request) {
+                      // If we are navigating to the destination url, allow it.
+                      if (request.url == _initialUrl) {
+                        return NavigationDecision.navigate;
+                      }
+
+                      // Otherwise, reject any navigation to other web urls
                       return NavigationDecision.prevent;
                     },
                     backgroundColor: const Color(0x00000000),

--- a/lib/screens/webview_screen.dart
+++ b/lib/screens/webview_screen.dart
@@ -8,6 +8,7 @@ import 'package:get/get.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 import '../utils/constants.dart';
+import '../widgets/tako_play_web_view.dart';
 
 class WebViewScreen extends StatefulWidget {
   const WebViewScreen({Key? key}) : super(key: key);
@@ -19,16 +20,10 @@ class WebViewScreen extends StatefulWidget {
 class _WebViewScreenState extends State<WebViewScreen> {
   var isLandScape = true.obs;
   final GlobalKey webViewKey = GlobalKey();
-  WebViewController? _webViewController;
-
-  /// The initial url to start with
-  late final String _initialUrl;
 
   @override
   void initState() {
     super.initState();
-    _initialUrl = Get.arguments['mediaUrl'].toString();
-
     if (Platform.isAndroid) WebView.platform = AndroidWebView();
     if (Platform.isIOS) WebView.platform = CupertinoWebView();
     SystemChrome.setPreferredOrientations([
@@ -91,55 +86,39 @@ class _WebViewScreenState extends State<WebViewScreen> {
               children: [
                 SizedBox.fromSize(
                   size: Size(screenWidth, screenHeight),
-                  child: WebView(
+                  child: TakoPlayWebView(
                     initialUrl: Get.arguments['mediaUrl'].toString(),
-                    javascriptMode: JavascriptMode.unrestricted,
-                    allowsInlineMediaPlayback: true,
-                    onWebViewCreated: (controller) async {
-                      _webViewController = controller;
-                    },
-                    onPageFinished: (_) async {
+                    onLoadingFinished: (_webViewController) async {
                       await Future.delayed(const Duration(seconds: 1));
-
                       try {
                         //
                         for (var i = 0; i < 8; i++) {
-                          await _webViewController!.runJavascriptReturningResult(
+                          await _webViewController.runJavascriptReturningResult(
                               "document.getElementsByTagName('iframe')[$i].style.display='none';");
-                          await _webViewController!.runJavascriptReturningResult(
+                          await _webViewController.runJavascriptReturningResult(
                               "document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].click();");
                         }
                         //
                         for (var i = 0; i < 8; i++) {
-                          await _webViewController!.runJavascriptReturningResult(
+                          await _webViewController.runJavascriptReturningResult(
                               "document.getElementsByTagName('iframe')[$i].style.display='none';");
                         }
-                        await _webViewController!.runJavascriptReturningResult(
+                        await _webViewController.runJavascriptReturningResult(
                             "document.getElementsByClassName('jw-icon jw-icon-inline jw-button-color jw-reset jw-icon-fullscreen')[1].click();");
-                        await _webViewController!.runJavascriptReturningResult(
+                        await _webViewController.runJavascriptReturningResult(
                             "if(document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].ariaLabel == 'Play'){document.getElementsByClassName('jw-icon jw-icon-display jw-button-color jw-reset')[0].click();}");
                         //
                         for (var i = 0; i < 8; i++) {
-                          await _webViewController!.runJavascriptReturningResult(
+                          await _webViewController.runJavascriptReturningResult(
                               "document.getElementsByTagName('iframe')[$i].style.display='none';");
                         }
                       } catch (e) {
                         print(
-                            'An error occurred while parsing data from webview:');
+                            'An error occurred while parsing data from webView:');
                         print(e.toString());
                         rethrow;
                       }
                     },
-                    navigationDelegate: (NavigationRequest request) {
-                      // If we are navigating to the destination url, allow it.
-                      if (request.url == _initialUrl) {
-                        return NavigationDecision.navigate;
-                      }
-
-                      // Otherwise, reject any navigation to other web urls
-                      return NavigationDecision.prevent;
-                    },
-                    backgroundColor: const Color(0x00000000),
                   ),
                 ),
                 Positioned(

--- a/lib/widgets/tako_play_web_view.dart
+++ b/lib/widgets/tako_play_web_view.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+/// [TakoPlayWebView] is a webview specifically tailored for the needs of the
+/// Tako Play app. Rather than always creating a webview and assigning it same
+/// values each time, this widget can be instantiated without going though that
+/// hassle.
+class TakoPlayWebView extends StatefulWidget {
+  const TakoPlayWebView({
+    required this.initialUrl,
+    this.onLoadingFinished,
+    Key? key,
+  }) : super(key: key);
+
+  /// Initial url of the web view
+  final String initialUrl;
+
+  /// Callback triggered once the page has finished loading
+  final Function(WebViewController)? onLoadingFinished;
+
+  @override
+  State<TakoPlayWebView> createState() => _TakoPlayWebViewState();
+}
+
+class _TakoPlayWebViewState extends State<TakoPlayWebView> {
+  WebViewController? _webViewController;
+
+  @override
+  Widget build(BuildContext context) => WebView(
+        initialUrl: widget.initialUrl,
+        javascriptMode: JavascriptMode.unrestricted,
+        allowsInlineMediaPlayback: true,
+        backgroundColor: const Color(0x00000000),
+        onWebViewCreated: (controller) async {
+          _webViewController = controller;
+        },
+        onPageFinished: (_) async {
+          if (_webViewController == null) return;
+          widget.onLoadingFinished?.call(_webViewController!);
+        },
+        navigationDelegate: (NavigationRequest request) {
+          // If we are navigating to the destination url, allow it.
+          if (request.url == widget.initialUrl) {
+            return NavigationDecision.navigate;
+          }
+
+          // Otherwise, reject any navigation to other web urls
+          return NavigationDecision.prevent;
+        },
+      );
+}


### PR DESCRIPTION
While testing the app on different devices I discovered that the webview wasn't working for most of them (unless I was using a VPN). With this PR I fixed two issues related to the webview player and slightly changed the code to make it easier to configure/change in the future.

The PR includes:
- A fix for a black screen showing forever when playing content using webview (this was happening in combination due to disallowed navigation policy and adds being fetched somehow?? with the JS calls)
- A fix for when local WebView settings aren't properly loaded unless manually toggled each time after killing the app
- Some slightly refactored code with an extracted (custom) widget called `TakoPlayWebView` and replaced the existing WebView widget with it where I found it. From now on, we can make changes to that widget and it will affect the rest of the app without rewriting or copy/pasting lots of code.